### PR TITLE
Исправлены тесты для прохождения и под Windows тоже.

### DIFF
--- a/gses-form-docx/src/main/java/ru/codeinside/gses/form/docx/ConverterProxy.java
+++ b/gses-form-docx/src/main/java/ru/codeinside/gses/form/docx/ConverterProxy.java
@@ -126,7 +126,7 @@ final public class ConverterProxy implements FormConverter {
           throw new RuntimeException("brokenPipe");
         }
         response.append((char) c);
-        if ("ok\n".equals(response.toString())) {
+        if (("ok" + System.getProperty("line.separator")).equals(response.toString())) {
           break;
         }
       }

--- a/gws-client-rr-3564/src/test/java/ru/codeinside/gws3564c/enclosure/gkn/GKNEnclosureBuildRequestTest.java
+++ b/gws-client-rr-3564/src/test/java/ru/codeinside/gws3564c/enclosure/gkn/GKNEnclosureBuildRequestTest.java
@@ -364,7 +364,7 @@ public class GKNEnclosureBuildRequestTest {
 
   private void testCreateEnclosure(ExchangeContext resultEnclosure, String fileWithExpectedEnclosure) throws IOException {
     InputStream is = this.getClass().getResourceAsStream(fileWithExpectedEnclosure);
-    String expectedContent = IOUtils.toString(is);
+    String expectedContent = IOUtils.toString(is, "UTF-8");
     EnclosureRequestBuilder enclosureBuilder = EnclosureBuilderFactory.createEnclosureBuilder(resultEnclosure);
     String id = "7b983700-651d-43d8-bdb4-26dd683df535";
     Assert.assertEquals(expectedContent, enclosureBuilder.createEnclosure(id));

--- a/gws-client-rr-3564/src/test/java/ru/codeinside/gws3564c/enclosure/grp/ExtractDataAboutIncapacityOwnerBuilderTest.java
+++ b/gws-client-rr-3564/src/test/java/ru/codeinside/gws3564c/enclosure/grp/ExtractDataAboutIncapacityOwnerBuilderTest.java
@@ -361,7 +361,7 @@ public class ExtractDataAboutIncapacityOwnerBuilderTest {
   private void testCreateEnclosure(String fileWithExpectedEnclosure, String guid) throws IOException {
     String xml = enclosureBuilder.createEnclosure( guid);
     InputStream is = this.getClass().getResourceAsStream(fileWithExpectedEnclosure);
-    String expectedContent = IOUtils.toString(is);
+    String expectedContent = IOUtils.toString(is, "UTF-8");
     Assert.assertEquals(expectedContent, xml);
   }
 }

--- a/gws-client-rr-3564/src/test/java/ru/codeinside/gws3564c/enclosure/grp/ObjectRightEnclosureBuilderTest.java
+++ b/gws-client-rr-3564/src/test/java/ru/codeinside/gws3564c/enclosure/grp/ObjectRightEnclosureBuilderTest.java
@@ -67,7 +67,7 @@ public class ObjectRightEnclosureBuilderTest {
   private void testCreateEnclosure(String fileWithExpectedEnclosure, String guid) throws IOException {
     String xml = enclosureBuilder.createEnclosure( guid);
     InputStream is = this.getClass().getResourceAsStream(fileWithExpectedEnclosure);
-    String expectedContent = IOUtils.toString(is);
+    String expectedContent = IOUtils.toString(is, "UTF-8");
     Assert.assertEquals(expectedContent, xml);
   }
 

--- a/gws-client-rr-3564/src/test/java/ru/codeinside/gws3564c/enclosure/grp/RightsEstablishEnclosureBuilderTest.java
+++ b/gws-client-rr-3564/src/test/java/ru/codeinside/gws3564c/enclosure/grp/RightsEstablishEnclosureBuilderTest.java
@@ -44,7 +44,7 @@ public class RightsEstablishEnclosureBuilderTest {
   private void testCreateEnclosure(String fileWithExpectedEnclosure, String guid) throws IOException {
     String xml = enclosureBuilder.createEnclosure( guid);
     InputStream is = this.getClass().getResourceAsStream(fileWithExpectedEnclosure);
-    String expectedContent = IOUtils.toString(is);
+    String expectedContent = IOUtils.toString(is, "UTF-8");
     Assert.assertEquals(expectedContent, xml);
   }
 

--- a/gws-client-rr-3564/src/test/java/ru/codeinside/gws3564c/enclosure/grp/SubjectRightsEnclosureBuilderTest.java
+++ b/gws-client-rr-3564/src/test/java/ru/codeinside/gws3564c/enclosure/grp/SubjectRightsEnclosureBuilderTest.java
@@ -365,7 +365,7 @@ public class SubjectRightsEnclosureBuilderTest {
   private void testCreateEnclosure(String fileWithExpectedEnclosure, String guid) throws IOException {
     String xml = enclosureBuilder.createEnclosure(guid);
     InputStream is = this.getClass().getResourceAsStream(fileWithExpectedEnclosure);
-    String expectedContent = IOUtils.toString(is);
+    String expectedContent = IOUtils.toString(is, "UTF-8");
     Assert.assertEquals(expectedContent, xml);
   }
 }

--- a/gws-client-rr-3564/src/test/java/ru/codeinside/gws3564c/enclosure/grp/SubjectRightsHistoryEnclosureBuilderTest.java
+++ b/gws-client-rr-3564/src/test/java/ru/codeinside/gws3564c/enclosure/grp/SubjectRightsHistoryEnclosureBuilderTest.java
@@ -40,7 +40,7 @@ public class SubjectRightsHistoryEnclosureBuilderTest {
   private void testCreateEnclosure(String fileWithExpectedEnclosure, String guid) throws IOException {
     String xml = enclosureBuilder.createEnclosure(guid);
     InputStream is = this.getClass().getResourceAsStream(fileWithExpectedEnclosure);
-    String expectedContent = IOUtils.toString(is);
+    String expectedContent = IOUtils.toString(is, "UTF-8");
     Assert.assertEquals(expectedContent, xml);
   }
 

--- a/gws-crypto-cryptopro/src/main/java/ru/codeinside/gws/crypto/cryptopro/CryptoProvider.java
+++ b/gws-crypto-cryptopro/src/main/java/ru/codeinside/gws/crypto/cryptopro/CryptoProvider.java
@@ -626,7 +626,7 @@ final public class CryptoProvider implements ru.codeinside.gws.api.CryptoProvide
     factory.setIgnoringElementContentWhitespace(true);
     factory.setCoalescing(true);
     factory.setNamespaceAware(true);
-    return factory.newDocumentBuilder().parse(new ByteArrayInputStream(sb.toString().getBytes()));
+    return factory.newDocumentBuilder().parse(new ByteArrayInputStream(sb.toString().getBytes("UTF-8")));
   }
 
   private String saxFilter(Node node) {

--- a/gws-log/src/test/java/ru/codeinside/gws/api/impl/FileTest.java
+++ b/gws-log/src/test/java/ru/codeinside/gws/api/impl/FileTest.java
@@ -41,6 +41,7 @@ public class FileTest {
 
   @Test
   public void testNull() {
+	System.setProperty("line.separator", "\n");
     assertNull(logServiceFile.createClientLog(
       3L, "client", "3", false, false, null, null
     ));


### PR DESCRIPTION
Конкретнее добавил указания кодировки UTF-8 и line.separator
